### PR TITLE
Add option to use custom logging level

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
       time: "07:00"
     versioning-strategy: lockfile-only
     allow:
-      - dependency-name: "configcat-js"
+      - dependency-name: "configcat-*"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ module.exports = function (environment) {
 | `pollIntervalSeconds`    | `60`       | Polling interval                                              | [🔗](https://configcat.com/docs/sdk-reference/js#auto-polling-default) |
 | `cacheTimeToLiveSeconds` | `60`       | Cache TTL                                                     | [🔗](https://configcat.com/docs/sdk-reference/js#lazy-loading)         |
 | `dataGovernance`         | `'Global'` | Determine the CDN location of the data: `'Global'`/`'EuOnly'` | [🔗](https://configcat.com/docs/advanced/data-governance)              |
+| `logLevel'               | -          | Set a custom log level                                        | [🔗](https://configcat.com/docs/sdk-reference/js/#logging)             |
 
 - `requestTimeoutMs` and `dataGovernance` are common polling options to the three available modes
 - All default values except `mode`, `local` and `autoStart` are defined in the ConfigCat SDK

--- a/addon/services/config-cat.ts
+++ b/addon/services/config-cat.ts
@@ -3,6 +3,7 @@ import {
   IJSAutoPollOptions,
   IJSLazyLoadingOptions,
   IJSManualPollOptions,
+  createConsoleLogger,
 } from 'configcat-js';
 import {
   createClientWithAutoPoll,
@@ -11,7 +12,7 @@ import {
 } from './-private/remote';
 import { createLocalClient } from './-private/local';
 import { tracked } from '@glimmer/tracking';
-import { IConfigCatClient, DataGovernance } from 'configcat-common';
+import { IConfigCatClient, DataGovernance, LogLevel } from 'configcat-common';
 import { getOwnConfig } from '@embroider/macros';
 
 enum PollModes {
@@ -35,6 +36,7 @@ interface EnvOptions {
   flags?: Flags;
   sdkKey?: string;
   requestTimeoutMs?: number;
+  logLevel?: LogLevel;
   dataGovernance?: DataGovernance;
   maxInitWaitTimeSeconds?: number;
   pollIntervalSeconds?: number;
@@ -68,6 +70,7 @@ export default class ConfigCat extends Service {
     const mode = envOptions.mode || PollModes.auto;
     const local = envOptions.local || !envOptions.sdkKey;
     const flags = envOptions.flags || {};
+    const logLevel = envOptions.logLevel;
 
     const options = {
       ...(envOptions.requestTimeoutMs && {
@@ -87,6 +90,9 @@ export default class ConfigCat extends Service {
         envOptions.pollIntervalSeconds && {
           pollIntervalSeconds: envOptions.pollIntervalSeconds,
         }),
+      ...(logLevel && {
+        logger: createConsoleLogger(logLevel),
+      }),
     };
 
     return {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@embroider/macros": "^0.47.0",
+    "configcat-common": "^4.5.0",
     "configcat-js": "^5.4.3",
     "ember-auto-import": "^2.2.0",
     "ember-cli-babel": "^7.26.3",

--- a/tests/unit/services/config-cat-test.ts
+++ b/tests/unit/services/config-cat-test.ts
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { createConsoleLogger } from 'configcat-js';
 
 module('Unit | Service | config-cat', function (hooks) {
   setupTest(hooks);
@@ -94,5 +95,47 @@ module('Unit | Service | config-cat', function (hooks) {
       dataGovernance: 'Global',
       maxInitWaitTimeSeconds: 300,
     });
+  });
+
+  test('it returns a config with a disabled logger', function (assert) {
+    const logLevel = -1;
+    const service = this.owner.lookup('service:config-cat');
+    const config = service.getAddonConfig({
+      logLevel,
+    });
+    assert.deepEqual(config.options.logger, createConsoleLogger(logLevel));
+  });
+
+  test('it returns a config with a logger set at info level', function (assert) {
+    const logLevel = 3;
+    const service = this.owner.lookup('service:config-cat');
+    const config = service.getAddonConfig({
+      logLevel,
+    });
+    assert.deepEqual(config.options.logger, createConsoleLogger(logLevel));
+  });
+
+  test('it returns a config with a logger set at warn level', function (assert) {
+    const logLevel = 2;
+    const service = this.owner.lookup('service:config-cat');
+    const config = service.getAddonConfig({
+      logLevel,
+    });
+    assert.deepEqual(config.options.logger, createConsoleLogger(logLevel));
+  });
+
+  test('it returns a config with a logger set at error level', function (assert) {
+    const logLevel = 1;
+    const service = this.owner.lookup('service:config-cat');
+    const config = service.getAddonConfig({
+      logLevel,
+    });
+    assert.deepEqual(config.options.logger, createConsoleLogger(logLevel));
+  });
+
+  test('it returns a config without logger', function (assert) {
+    const service = this.owner.lookup('service:config-cat');
+    const config = service.getAddonConfig({});
+    assert.strictEqual(config.options.logger, undefined);
   });
 });


### PR DESCRIPTION
This PR is adding a new option to allow user setting a custom logging level - https://configcat.com/docs/sdk-reference/js/#logging