### PR TITLE
Lint | Import types accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ export default class WhateverComponent extends Component {
 
 ```js
 // ...
-import { setupConfigCat, TestContext } from 'ember-config-cat/test-support';
+import { setupConfigCat, type TestContext } from 'ember-config-cat/test-support';
 
 module('...', function (hooks) {
   // ...

--- a/test-app/tests/acceptance/helper-test.ts
+++ b/test-app/tests/acceptance/helper-test.ts
@@ -1,7 +1,10 @@
 import { module, test } from 'qunit';
 import { visit, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { setupConfigCat, TestContext } from 'ember-config-cat/test-support';
+import {
+  setupConfigCat,
+  type TestContext,
+} from 'ember-config-cat/test-support';
 
 module('Acceptance | helper', function (hooks) {
   setupApplicationTest(hooks);

--- a/test-app/tests/integration/helpers/get-flag-value-test.ts
+++ b/test-app/tests/integration/helpers/get-flag-value-test.ts
@@ -2,7 +2,10 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupConfigCat, TestContext } from 'ember-config-cat/test-support';
+import {
+  setupConfigCat,
+  type TestContext,
+} from 'ember-config-cat/test-support';
 
 module('Integration | Helper | get-flag-value', function (hooks) {
   setupRenderingTest(hooks);

--- a/test-app/tests/integration/helpers/has-flag-value-test.ts
+++ b/test-app/tests/integration/helpers/has-flag-value-test.ts
@@ -2,7 +2,10 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupConfigCat, TestContext } from 'ember-config-cat/test-support';
+import {
+  setupConfigCat,
+  type TestContext,
+} from 'ember-config-cat/test-support';
 
 module('Integration | Helper | has-flag-value', function (hooks) {
   setupRenderingTest(hooks);

--- a/test-app/tests/integration/helpers/is-flag-enabled-test.ts
+++ b/test-app/tests/integration/helpers/is-flag-enabled-test.ts
@@ -2,7 +2,10 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupConfigCat, TestContext } from 'ember-config-cat/test-support';
+import {
+  setupConfigCat,
+  type TestContext,
+} from 'ember-config-cat/test-support';
 
 module('Integration | Helper | is-flag-enabled', function (hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
Fixing CI https://github.com/MakeMusicInc/ember-config-cat/actions/runs/7018574728/job/19094257889
Using the keyword type when importing types https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax

```
 Error: [lint] [lint:types] tests/acceptance/helper-test.ts(4,26): error TS1484: 'TestContext' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
Error: [lint] [lint:types] tests/integration/helpers/get-flag-value-test.ts(5,26): error TS1484: 'TestContext' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
Error: [lint] [lint:types] tests/integration/helpers/has-flag-value-test.ts(5,26): error TS1484: 'TestContext' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
Error: [lint] [lint:types] tests/integration/helpers/is-flag-enabled-test.ts(5,26): error TS1484: 'TestContext' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
```